### PR TITLE
Hotfix/uint8 image streaming

### DIFF
--- a/steganography-web/pages/index.tsx
+++ b/steganography-web/pages/index.tsx
@@ -52,7 +52,16 @@ const Home: NextPage = () => {
       body: formData
     })
     const reader = response.body!.getReader()
-    const { value: uint8array } = await reader.read()
+    let uint8array: Uint8Array = new Uint8Array()
+    let notEmpty = true
+    while (notEmpty) {
+      const { value: uint8arrayChunk } = await reader.read()
+      if (uint8arrayChunk != undefined){
+        uint8array = new Uint8Array([...uint8array, ...uint8arrayChunk])
+      } else {
+        notEmpty = false
+      }
+    }
     // Get from client side
     if (uint8array !== undefined){
       const myBlob = new Blob([uint8array], { type: 'image/png' })

--- a/steganography-web/tsconfig.json
+++ b/steganography-web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
readableStream 객체에서 read를 하는 경우
한 개의 chunk 단위로 데이터를 받아오기 때문에
데이터를 모두 받아오기 전까지 반복하여 가져오는 작업이 필요하다.

chunk를 계속 쌓아둘 uint8 buffer를 하나 생성하였고
쌓인 chunk를 이미지 형식으로 보여줄 수 있었다.